### PR TITLE
ADEV-23 : Activer les fenced code blocks dans Pegdown

### DIFF
--- a/site/src/main/java/com/google/gwt/site/markdown/pegdown/MarkdownToHtmlUtil.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/pegdown/MarkdownToHtmlUtil.java
@@ -32,7 +32,7 @@ public class MarkdownToHtmlUtil {
     private final List<ToHtmlSerializerPlugin> plugins;
 
     public MarkdownToHtmlUtil() {
-        this(new PegDownProcessor(Extensions.NONE, Long.MAX_VALUE, getPlugins()));
+        this(new PegDownProcessor(Extensions.FENCED_CODE_BLOCKS, Long.MAX_VALUE, getPlugins()));
     }
 
     private static PegDownPlugins getPlugins() {


### PR DESCRIPTION
@jasonlemay Les blocs inline sont transformé en 
`<code>blah</code>` et les fenced blocks en `<pre><code>blah</code></pre>` avec cette PR.

Je crois que ça devrait être suffisant pour ADEV-25
