### PR TITLE
ADEV-8 Applied uniform copyright headers

### DIFF
--- a/site/src/main/java/com/google/gwt/site/markdown/MDHelper.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/MDHelper.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/site/src/main/java/com/google/gwt/site/markdown/MDHelperException.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/MDHelperException.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown;

--- a/site/src/main/java/com/google/gwt/site/markdown/MDTranslater.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/MDTranslater.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/site/src/main/java/com/google/gwt/site/markdown/MarkDown.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/MarkDown.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/site/src/main/java/com/google/gwt/site/markdown/MarkupWriter.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/MarkupWriter.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown;

--- a/site/src/main/java/com/google/gwt/site/markdown/Strings.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/Strings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/site/src/main/java/com/google/gwt/site/markdown/TranslaterException.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/TranslaterException.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown;

--- a/site/src/main/java/com/google/gwt/site/markdown/Util.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/Util.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown;

--- a/site/src/main/java/com/google/gwt/site/markdown/fs/FileSystemTraverser.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/fs/FileSystemTraverser.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.fs;

--- a/site/src/main/java/com/google/gwt/site/markdown/fs/MDNode.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/fs/MDNode.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.fs;

--- a/site/src/main/java/com/google/gwt/site/markdown/fs/MDParent.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/fs/MDParent.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.fs;

--- a/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdHtmlSerializerPlugin.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdHtmlSerializerPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdNode.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdParserPlugin.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/pegdown/DivWithIdParserPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/site/src/main/java/com/google/gwt/site/markdown/pegdown/MarkdownToHtmlUtil.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/pegdown/MarkdownToHtmlUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/site/src/main/java/com/google/gwt/site/markdown/toc/TocCreator.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/toc/TocCreator.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.toc;

--- a/site/src/main/java/com/google/gwt/site/markdown/toc/TocFromMdCreator.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/toc/TocFromMdCreator.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.toc;

--- a/site/src/main/java/com/google/gwt/site/markdown/toc/TocFromTemplateCreator.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/toc/TocFromTemplateCreator.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.markdown.toc;

--- a/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityEngineProvider.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityEngineProvider.java
@@ -1,10 +1,17 @@
 /**
- * Copyright (c) 2014 by ArcBees Inc., All rights reserved.
- * This source code, and resulting software, is the confidential and proprietary information
- * ("Proprietary Information") and is the intellectual property ("Intellectual Property")
- * of ArcBees Inc. ("The Company"). You shall not disclose such Proprietary Information and
- * shall use it only in accordance with the terms and conditions of any and all license
- * agreements you have entered into with The Company.
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.gwt.site.markdown.velocity;

--- a/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityWrapper.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityWrapper.java
@@ -1,10 +1,17 @@
 /**
- * Copyright (c) 2014 by ArcBees Inc., All rights reserved.
- * This source code, and resulting software, is the confidential and proprietary information
- * ("Proprietary Information") and is the intellectual property ("Intellectual Property")
- * of ArcBees Inc. ("The Company"). You shall not disclose such Proprietary Information and
- * shall use it only in accordance with the terms and conditions of any and all license
- * agreements you have entered into with The Company.
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.gwt.site.markdown.velocity;

--- a/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityWrapperFactory.java
+++ b/site/src/main/java/com/google/gwt/site/markdown/velocity/VelocityWrapperFactory.java
@@ -1,10 +1,17 @@
 /**
- * Copyright (c) 2014 by ArcBees Inc., All rights reserved.
- * This source code, and resulting software, is the confidential and proprietary information
- * ("Proprietary Information") and is the intellectual property ("Intellectual Property")
- * of ArcBees Inc. ("The Company"). You shall not disclose such Proprietary Information and
- * shall use it only in accordance with the terms and conditions of any and all license
- * agreements you have entered into with The Company.
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.gwt.site.markdown.velocity;

--- a/site/src/test/java/com/google/gwt/site/markdown/MDTranslaterTest.java
+++ b/site/src/test/java/com/google/gwt/site/markdown/MDTranslaterTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/CredentialsProvider.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/CredentialsProvider.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/FileTraverser.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/FileTraverser.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/FileTraverserFileSystemImpl.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/FileTraverserFileSystemImpl.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/HashCalculator.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/HashCalculator.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/HashCalculatorSha1Impl.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/HashCalculatorSha1Impl.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/InitializeException.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/InitializeException.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/ResourceUploader.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/ResourceUploader.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/ResourceUploaderAppEngineImpl.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/ResourceUploaderAppEngineImpl.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/SaveCredentials.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/SaveCredentials.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/UploadController.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/UploadController.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/Uploader.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/Uploader.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/model/LocalResource.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/model/LocalResource.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/model/Resource.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/model/Resource.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/main/java/com/google/gwt/site/uploader/model/ResourceKey.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/model/ResourceKey.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/test/java/com/google/gwt/site/uploader/FileTraverserTest.java
+++ b/uploader/src/test/java/com/google/gwt/site/uploader/FileTraverserTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/test/java/com/google/gwt/site/uploader/HashCalculatorTest.java
+++ b/uploader/src/test/java/com/google/gwt/site/uploader/HashCalculatorTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/test/java/com/google/gwt/site/uploader/ResourceUploaderTest.java
+++ b/uploader/src/test/java/com/google/gwt/site/uploader/ResourceUploaderTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/uploader/src/test/java/com/google/gwt/site/uploader/UploadControllerTest.java
+++ b/uploader/src/test/java/com/google/gwt/site/uploader/UploadControllerTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/webapp/src/main/java/com/arcbees/analytics/client/ClientAnalyticsFactory.java
+++ b/webapp/src/main/java/com/arcbees/analytics/client/ClientAnalyticsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 ArcBees Inc.
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/AbstractDemos.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/AbstractDemos.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/ContentLoadedEvent.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/ContentLoadedEvent.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/GSSSAnimationDemos.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/GSSSAnimationDemos.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/examples/Examples.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/examples/Examples.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/resources/AnimationResources.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/animation/resources/AnimationResources.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/GSSSGridDemos.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/GSSSGridDemos.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/examples/Examples.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/examples/Examples.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/resources/GridResources.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/grid/resources/GridResources.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/GSSSMixinsDemos.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/GSSSMixinsDemos.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/examples/Examples.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/examples/Examples.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/resources/MixinsResources.java
+++ b/webapp/src/main/java/com/google/gwt/site/demo/gsss/mixins/resources/MixinsResources.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014 ArcBees Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/webapp/src/main/java/com/google/gwt/site/webapp/client/GWTProjectEntryPoint.java
+++ b/webapp/src/main/java/com/google/gwt/site/webapp/client/GWTProjectEntryPoint.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/webapp/src/main/java/com/google/gwt/site/webapp/server/guice/GuiceServletConfig.java
+++ b/webapp/src/main/java/com/google/gwt/site/webapp/server/guice/GuiceServletConfig.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.webapp.server.guice;

--- a/webapp/src/main/java/com/google/gwt/site/webapp/server/guice/MyServletModule.java
+++ b/webapp/src/main/java/com/google/gwt/site/webapp/server/guice/MyServletModule.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.webapp.server.guice;

--- a/webapp/src/main/java/com/google/gwt/site/webapp/server/resources/ContentServlet.java
+++ b/webapp/src/main/java/com/google/gwt/site/webapp/server/resources/ContentServlet.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.gwt.site.webapp.server.resources;

--- a/webapp/src/main/java/com/google/gwt/site/webapp/server/resources/HashServlet.java
+++ b/webapp/src/main/java/com/google/gwt/site/webapp/server/resources/HashServlet.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/webapp/src/test/java/com/google/gwt/site/webapp/client/ProjectEntryPointGwtTest.java
+++ b/webapp/src/test/java/com/google/gwt/site/webapp/client/ProjectEntryPointGwtTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 

--- a/webapp/src/test/java/com/google/gwt/site/webapp/client/ProjectEntryPointTest.java
+++ b/webapp/src/test/java/com/google/gwt/site/webapp/client/ProjectEntryPointTest.java
@@ -1,14 +1,16 @@
-/*
- * Copyright 2013 Google Inc.
+/**
+ * Copyright 2015 ArcBees Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
  * the License.
  */
 


### PR DESCRIPTION
I'm not sure if overriding Google -> Arcbees in copyright headers is a good/bad thing though.