### PR TITLE
Rework POMs + tweak uploader and webapp to use app IDs not hard-coded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,346 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.arcbees.website.dev</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <url>http://dev.arcbees.com/</url>
+
+    <modules>
+        <module>site</module>
+        <module>uploader</module>
+        <module>webapp</module>
+    </modules>
+
+    <properties>
+        <jdk.version>1.7</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Compile dependencies -->
+        <appengine.version>1.9.19</appengine.version>
+        <commons-codec.version>1.10</commons-codec.version>
+        <commons-io.version>2.4</commons-io.version>
+        <guice.version>3.0</guice.version>
+        <guava.version>18.0</guava.version>
+        <javax.inject.version>1</javax.inject.version>
+        <json.version>20140107</json.version>
+        <pegdown.version>1.4.2</pegdown.version>
+        <velocity.version>1.7</velocity.version>
+
+        <!-- Provided dependencies -->
+        <gwt.version>2.7.0</gwt.version>
+        <gwtquery.version>1.4.3</gwtquery.version>
+        <gsss.version>1.0</gsss.version>
+        <servlet.version>2.5</servlet.version>
+        <universal-analytics.version>2.1</universal-analytics.version>
+
+        <!-- Test dependencies -->
+        <junit.version>4.12</junit.version>
+        <mockito.version>1.10.19</mockito.version>
+        <assertj-core.version>1.7.0</assertj-core.version>
+
+        <!-- Plugin dependencies -->
+        <checkstyle.version>6.0</checkstyle.version>
+        <build-tools.version>1.2</build-tools.version>
+
+        <!-- Plugins -->
+        <assembly-plugin.version>2.5.3</assembly-plugin.version>
+        <appengine-plugin.version>1.9.19-SNAPSHOT</appengine-plugin.version>
+        <checkstyle-plugin.version>2.15</checkstyle-plugin.version>
+        <compiler-plugin.version>3.3</compiler-plugin.version>
+        <dependency-plugin.version>2.10</dependency-plugin.version>
+        <deploy-plugin.version>2.8.2</deploy-plugin.version>
+        <exec-plugin.version>1.3.2</exec-plugin.version>
+        <gwt-plugin.version>2.7.0</gwt-plugin.version>
+        <resources-plugin.version>2.7</resources-plugin.version>
+        <surefire-plugin.version>2.18.1</surefire-plugin.version>
+        <war-plugin.version>2.6</war-plugin.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Compile dependencies -->
+            <dependency>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-api-1.0-sdk</artifactId>
+                <version>${appengine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-remote-api</artifactId>
+                <version>${appengine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-tools-sdk</artifactId>
+                <version>${appengine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-servlet</artifactId>
+                <version>${guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>${javax.inject.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.pegdown</groupId>
+                <artifactId>pegdown</artifactId>
+                <version>${pegdown.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity</artifactId>
+                <version>${velocity.version}</version>
+            </dependency>
+
+            <!-- Provided dependencies -->
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>${servlet.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
+                <version>${gwt.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-dev</artifactId>
+                <version>${gwt.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava-gwt</artifactId>
+                <version>${guava.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.gwtquery</groupId>
+                <artifactId>gwtquery</artifactId>
+                <version>${gwtquery.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.arcbees.gss</groupId>
+                <artifactId>gsss</artifactId>
+                <version>${gsss.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.arcbees.analytics</groupId>
+                <artifactId>universal-analytics</artifactId>
+                <version>${universal-analytics.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-testing</artifactId>
+                <version>${appengine.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.appengine</groupId>
+                <artifactId>appengine-api-stubs</artifactId>
+                <version>${appengine.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${assembly-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.arcbees.appengine</groupId>
+                    <artifactId>appengine-maven-plugin</artifactId>
+                    <version>${appengine-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${checkstyle-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${dependency-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${exec-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>gwt-maven-plugin</artifactId>
+                    <version>${gwt-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${resources-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${war-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+
+                <configuration>
+                    <configLocation>/checkstyle.xml</configLocation>
+                    <suppressionsLocation>/suppressions.xml</suppressionsLocation>
+                    <cacheFile>target/checkstyle-cachefile</cacheFile>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <linkXRef>false</linkXRef>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>com.arcbees</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${build-tools.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                        <exclusions>
+                            <exclusion>
+                                <groupId>com.sun</groupId>
+                                <artifactId>tools</artifactId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -1,48 +1,50 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.google.gwt.site</groupId>
-    <artifactId>gwt-site</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <parent>
+        <groupId>com.arcbees.website.dev</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>markdown</artifactId>
     <packaging>jar</packaging>
 
-    <name>markdown</name>
-    <url>http://www.gwtproject.org</url>
-
     <properties>
-        <build-tools.version>1.0</build-tools.version>
-        <checkstyle.version>6.0</checkstyle.version>
+        <plexus-io.version>2.5</plexus-io.version>
 
-        <velocity.version>1.7</velocity.version>
-        <junit.version>4.11</junit.version>
-        <pegdown.version>1.4.2</pegdown.version>
-        <commons-io.version>2.4</commons-io.version>
-
-        <maven-compiler-plugin.version>3.2</maven-compiler-plugin.version>
-        <maven-checkstyle-plugin.version>2.13</maven-checkstyle-plugin.version>
-        <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
-        <exec-maven-plugin.version>1.3.2</exec-maven-plugin.version>
-
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <jdk.version>1.7</jdk.version>
-        <assertj-core.version>1.7.0</assertj-core.version>
+        <jar-plugin.version>2.6</jar-plugin.version>
+        <jetty-maven-plugin.version>8.1.9.v20130131</jetty-maven-plugin.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.pegdown</groupId>
+            <artifactId>pegdown</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <resources>
@@ -56,27 +58,53 @@
                 <directory>src/main/site</directory>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <version>${maven-compiler-plugin.version}</version>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
 
+        <pluginManagement>
+            <plugins>
+                <!-- Run site locally: mvn jetty:run -->
+                <plugin>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <version>${jetty-maven-plugin.version}</version>
+
+                    <configuration>
+                        <webAppSourceDirectory>${project.build.directory}/generated-site</webAppSourceDirectory>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${jar-plugin.version}</version>
+
+                    <dependencies>
+                        <!-- Work around a performance issue with Maven and Java 7:
+                          Maven has a dependency that does a getgrgid for each file.
+                          This is very slow for large groups, and not cached.
+                          See issue: http://jira.codehaus.org/browse/PLXCOMP-203
+                        -->
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-io</artifactId>
+                            <version>${plexus-io.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec-maven-plugin.version}</version>
+
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>java</goal>
                         </goals>
+
                         <configuration>
                             <mainClass>com.google.gwt.site.markdown.MarkDown</mainClass>
                             <arguments>
@@ -90,8 +118,9 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resources-plugin.version}</version>
+
                 <executions>
                     <execution>
                         <id>copy doc resources</id>
@@ -99,13 +128,14 @@
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
+
                         <configuration>
+                            <outputDirectory>${basedir}/target/generated-site</outputDirectory>
                             <nonFilteredFileExtensions>
                                 <nonFilteredFileExtension>woff</nonFilteredFileExtension>
                                 <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
                                 <nonFilteredFileExtension>eot</nonFilteredFileExtension>
                             </nonFilteredFileExtensions>
-                            <outputDirectory>${basedir}/target/generated-site</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/main/site/</directory>
@@ -117,7 +147,9 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>assemble</id>
@@ -127,133 +159,13 @@
                         </goals>
                     </execution>
                 </executions>
+
                 <configuration>
                     <descriptors>
                         <descriptor>src/main/assembly/generated-site.xml</descriptor>
                     </descriptors>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
-
-                <configuration>
-                    <configLocation>/checkstyle.xml</configLocation>
-                    <suppressionsLocation>/suppressions.xml</suppressionsLocation>
-                    <cacheFile>target/checkstyle-cachefile</cacheFile>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.arcbees</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${build-tools.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>com.sun</groupId>
-                                <artifactId>tools</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>checkstyle</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <!-- Run site locally: mvn jetty:run -->
-                <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty-maven-plugin</artifactId>
-                    <version>8.1.9.v20130131</version>
-                    <configuration>
-                        <webAppSourceDirectory>${project.build.directory}/generated-site</webAppSourceDirectory>
-                    </configuration>
-                </plugin>
-                <!-- Work around a performance issue with Maven and Java 7:
-                  Maven has a dependency that does a getgrgid for each file.
-                  This is very slow for large groups, and not cached.
-                  See issue: http://jira.codehaus.org/browse/PLXCOMP-203
-                -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-io</artifactId>
-                            <version>2.0.5</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>${velocity.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.pegdown</groupId>
-            <artifactId>pegdown</artifactId>
-            <version>${pegdown.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.arcbees</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${build-tools.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -15,7 +15,7 @@
         <plexus-io.version>2.5</plexus-io.version>
 
         <jar-plugin.version>2.6</jar-plugin.version>
-        <jetty-maven-plugin.version>8.1.9.v20130131</jetty-maven-plugin.version>
+        <jetty-maven-plugin.version>9.2.10.v20150310</jetty-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -63,7 +63,7 @@
             <plugins>
                 <!-- Run site locally: mvn jetty:run -->
                 <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
+                    <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty-maven-plugin.version}</version>
 

--- a/uploader/pom.xml
+++ b/uploader/pom.xml
@@ -1,87 +1,63 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.google.gwt.site</groupId>
+
+    <parent>
+        <groupId>com.arcbees.website.dev</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
     <artifactId>uploader</artifactId>
-    <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven-checkstyle-plugin.version>2.13</maven-checkstyle-plugin.version>
-        <checkstyle.version>6.0</checkstyle.version>
-        <build-tools.version>1.0-SNAPSHOT</build-tools.version>
-        <jdk.version>1.7</jdk.version>
+        <appengine.credentials>credentials</appengine.credentials>
+        <directory.unpack>arcbees-markdown-unpack</directory.unpack>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>com.google.gwt.site</groupId>
-            <artifactId>gwt-site</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <groupId>com.arcbees.website.dev</groupId>
+            <artifactId>markdown</artifactId>
+            <version>${project.version}</version>
             <type>zip</type>
             <classifier>generated-site</classifier>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>14.0.1</version>
-        </dependency>
+
+        <!-- Compile dependencies -->
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-tools-sdk</artifactId>
-            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-remote-api</artifactId>
-            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20090211</version>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.arcbees</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${build-tools.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -89,18 +65,8 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <version>2.5.1</version>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.7</version>
+
                 <executions>
                     <execution>
                         <id>unpack-dependencies</id>
@@ -108,54 +74,12 @@
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
+
                         <configuration>
-                            <includeGroupIds>com.google.gwt.site</includeGroupIds>
-                            <includeArtifactIds>gwt-site</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}/gwt-site-unpack</outputDirectory>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeArtifactIds>markdown</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}/${directory.unpack}</outputDirectory>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
-
-                <configuration>
-                    <configLocation>/checkstyle.xml</configLocation>
-                    <suppressionsLocation>/suppressions.xml</suppressionsLocation>
-                    <cacheFile>target/checkstyle-cachefile</cacheFile>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.arcbees</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${build-tools.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>com.sun</groupId>
-                                <artifactId>tools</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>checkstyle</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -163,8 +87,31 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.1.1</version>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>upload</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+
+                        <configuration>
+                            <mainClass>com.google.gwt.site.uploader.Uploader</mainClass>
+
+                            <arguments>
+                                <argument>${project.build.directory}/${directory.unpack}</argument>
+                                <argument>${appengine.credentials}</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/uploader/src/main/java/com/google/gwt/site/uploader/SaveCredentials.java
+++ b/uploader/src/main/java/com/google/gwt/site/uploader/SaveCredentials.java
@@ -48,23 +48,26 @@ public class SaveCredentials {
             System.exit(1);
         }
 
-        p("Please enter your gwtproject.org credentials.");
+        p("Please enter your dev.arcbees.com credentials.");
 
+        String appId;
         String email;
         String password;
 
         if (System.console() != null) {
+            appId = System.console().readLine("Application ID: ");
             email = System.console().readLine("Email: ");
             password = new String(System.console().readPassword("Password: "));
         } else  {
             BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-            String[] strings = new String(reader.readLine().toCharArray()).split("#");
-            email = strings[0];
-            password = strings[1];
+            String[] strings = new String(reader.readLine().toCharArray()).split("#", 3);
+            appId = strings[0];
+            email = strings[1];
+            password = strings[2];
         }
 
         RemoteApiOptions options =
-                new RemoteApiOptions().server("docs-site.appspot.com", 443).credentials(email, password);
+                new RemoteApiOptions().server(appId + ".appspot.com", 443).credentials(email, password);
         RemoteApiInstaller installer = new RemoteApiInstaller();
         installer.install(options);
         // test the connection

--- a/uploader/upload.sh
+++ b/uploader/upload.sh
@@ -4,4 +4,4 @@
 # Run with 'credentials' (after running save_credentials.sh) to deploy to prod.
 
 mvn -q compile generate-resources
-mvn -q exec:java -Dexec.mainClass=com.google.gwt.site.uploader.Uploader -Dexec.args="target/gwt-site-unpack $1"
+mvn -q exec:java -Dexec.mainClass=com.google.gwt.site.uploader.Uploader -Dexec.args="target/arcbees-markdown-unpack $1"

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -1,161 +1,90 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.google.gwt.site.webapp</groupId>
-    <artifactId>gwt-site-webapp</artifactId>
-    <version>1.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>com.arcbees.website.dev</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>webapp</artifactId>
     <packaging>war</packaging>
 
     <properties>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-        <appengine.app.version>${maven.build.timestamp}</appengine.app.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <appengine.target.version>1.9.17</appengine.target.version>
-        <json.version>20140107</json.version>
-        <commons-codec.version>1.9</commons-codec.version>
-        <checkstyle.version>6.0</checkstyle.version>
-        <build-tools.version>1.0-SNAPSHOT</build-tools.version>
-
-        <!-- javax -->
-        <servlet.version>2.5</servlet.version>
-        <universal-analytics.version>2.1</universal-analytics.version>
-
-        <gwt.version>2.7.0</gwt.version>
-        <gwtquery.version>1.4.2</gwtquery.version>
-
-        <!-- Demos -->
-        <gsss.version>1.0-SNAPSHOT</gsss.version>
-        <guava.version>18.0</guava.version>
-
-        <junit.version>4.11</junit.version>
-
-        <!-- plugin -->
-        <surefire-plugin.version>2.17</surefire-plugin.version>
-        <compiler-plugin.version>3.1</compiler-plugin.version>
-        <war-plugin.version>2.5</war-plugin.version>
-        <eclipse-plugin.version>2.9</eclipse-plugin.version>
-        <appengine.plugin.version>1.9.17</appengine.plugin.version>
-        <maven-checkstyle-plugin.version>2.13</maven-checkstyle-plugin.version>
-
-        <jdk.version>1.7</jdk.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencies>
-        <!-- Compile/runtime dependencies -->
+        <dependency>
+            <groupId>com.arcbees.website.dev</groupId>
+            <artifactId>markdown</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>generated-site</classifier>
+        </dependency>
+
+        <!-- Compile dependencies -->
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>${appengine.target.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>${servlet.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
-            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-gwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.gwtquery</groupId>
+            <artifactId>gwtquery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.arcbees.gss</groupId>
+            <artifactId>gsss</artifactId>
         </dependency>
         <dependency>
             <groupId>com.arcbees.analytics</groupId>
             <artifactId>universal-analytics</artifactId>
-            <version>${universal-analytics.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-testing</artifactId>
-            <version>${appengine.target.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-stubs</artifactId>
-            <version>${appengine.target.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- UI dependencies -->
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-user</artifactId>
-            <version>${gwt.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.gwtquery</groupId>
-            <artifactId>gwtquery</artifactId>
-            <version>${gwtquery.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <version>${gwt.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt.site</groupId>
-            <artifactId>gwt-site</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <classifier>generated-site</classifier>
-        </dependency>
-        <dependency>
-            <groupId>com.arcbees</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${build-tools.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- DEMO Dependencies -->
-        <!-- GSSS -->
-        <dependency>
-            <groupId>com.arcbees.gss</groupId>
-            <artifactId>gsss</artifactId>
-            <version>${gsss.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava-gwt</artifactId>
-            <version>${guava.version}</version>
         </dependency>
     </dependencies>
 
@@ -173,7 +102,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire-plugin.version}</version>
+
                 <configuration>
                     <excludes>
                         <exclude>**/*GwtTest.java</exclude>
@@ -183,20 +112,18 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${compiler-plugin.version}</version>
+                <artifactId>maven-deploy-plugin</artifactId>
+
                 <configuration>
-                    <source>${jdk.version}</source>
-                    <target>${jdk.version}</target>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>${war-plugin.version}</version>
+
                 <configuration>
-                    <!-- <archiveClasses>true</archiveClasses> -->
                     <webResources>
                         <!-- in order to interpolate version from pom into appengine-web.xml -->
                         <resource>
@@ -222,63 +149,31 @@
             </plugin>
 
             <plugin>
-                <groupId>com.google.appengine</groupId>
+                <groupId>com.arcbees.appengine</groupId>
                 <artifactId>appengine-maven-plugin</artifactId>
-                <version>${appengine.plugin.version}</version>
+
                 <configuration>
+                    <appId>${appengine.app.id}</appId>
                     <version>${appengine.app.version}</version>
                     <address>0.0.0.0</address>
                 </configuration>
-            </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>${eclipse-plugin.version}</version>
-                <configuration>
-                    <downloadSources>true</downloadSources>
-                    <downloadJavadocs>false</downloadJavadocs>
-                    <buildOutputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes
-                    </buildOutputDirectory>
-                    <projectnatures>
-                        <projectnature>org.eclipse.jdt.core.javanature</projectnature>
-                        <projectnature>com.google.gdt.eclipse.core.webAppNature</projectnature>
-                        <nature>com.google.appengine.eclipse.core.gaeNature</nature>
-                        <nature>com.google.gwt.eclipse.core.gwtNature</nature>
-                    </projectnatures>
-                    <buildcommands>
-                        <buildcommand>org.eclipse.jdt.core.javabuilder</buildcommand>
-                        <buildcommand>com.google.gdt.eclipse.core.webAppProjectValidator</buildcommand>
-                        <buildcommand>com.google.appengine.eclipse.core.projectValidator</buildcommand>
-                        <buildcommand>com.google.gwt.eclipse.core.gwtProjectValidator</buildcommand>
-                        <buildcommand>com.google.appengine.eclipse.core.enhancerbuilder</buildcommand>
-                    </buildcommands>
-                    <classpathContainers>
-                        <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER</classpathContainer>
-                        <classpathContainer>com.google.appengine.eclipse.core.GAE_CONTAINER</classpathContainer>
-                        <classpathContainer>com.google.gwt.eclipse.core.GWT_CONTAINER</classpathContainer>
-                    </classpathContainers>
-                    <excludes>
-                        <exclude>com.google.gwt:gwt-servlet</exclude>
-                        <exclude>com.google.gwt:gwt-user</exclude>
-                        <exclude>com.google.gwt:gwt-dev</exclude>
-                        <exclude>javax.validation:validation-api</exclude>
-                        <exclude>com.google.appengine:appengine-api-1.0-sdk</exclude>
-                        <exclude>com.google.appengine:appengine-api-stubs</exclude>
-                        <exclude>com.google.appengine:appengine-testing</exclude>
-                        <exclude>org.datanucleus:datanucleus-core</exclude>
-                        <exclude>org.datanucleus:datanucleus-enhancer</exclude>
-                        <exclude>org.datanucleus:datanucleus-jpa</exclude>
-                        <exclude>org.datanucleus:datanucleus-api-jdo</exclude>
-                        <exclude>com.google.appengine.orm:datanucleus-appengine</exclude>
-                    </excludes>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>update</id>
+                        <phase>deploy</phase>
+
+                        <goals>
+                            <goal>update</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>${gwt.version}</version>
+
                 <executions>
                     <execution>
                         <configuration>
@@ -286,13 +181,13 @@
                             <includes>**/*GwtTest.java</includes>
                             <mode>htmlunit</mode>
                             <gen>gen</gen>
-                            <extraJvmArgs>-Xss1024k -Xmx512M -XX:MaxPermSize=512m -Duser.language=en
-                                -Duser.country=US
+                            <extraJvmArgs>-Xss1024k -Xmx512M -XX:MaxPermSize=512m -Duser.language=en -Duser.country=US
                             </extraJvmArgs>
                             <saveSource>true</saveSource>
                             <module>com.google.gwt.site.webapp.GWTProject</module>
                             <style>OBF</style>
                         </configuration>
+
                         <goals>
                             <goal>compile</goal>
                             <goal>test</goal>
@@ -300,8 +195,11 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>unpack-dependencies</id>
@@ -309,17 +207,21 @@
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
+
                         <configuration>
-                            <includeGroupIds>com.google.gwt.site</includeGroupIds>
-                            <includeArtifactIds>gwt-site</includeArtifactIds>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeArtifactIds>markdown</includeArtifactIds>
                             <excludeTransitive>true</excludeTransitive>
                             <outputDirectory>${project.build.directory}/www/</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+
                 <executions>
                     <execution>
                         <id>copy-resources</id>
@@ -332,7 +234,7 @@
                             <resources>
                                 <resource>
                                     <directory>
-                                        ${project.build.directory}/${project.artifactId}-${project.version}/gwtproject/
+                                        ${project.build.directory}/${project.build.finalName}/gwtproject/
                                     </directory>
                                 </resource>
                             </resources>
@@ -340,48 +242,46 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${maven-checkstyle-plugin.version}</version>
-
-                <configuration>
-                    <configLocation>/checkstyle.xml</configLocation>
-                    <suppressionsLocation>/suppressions.xml</suppressionsLocation>
-                    <cacheFile>target/checkstyle-cachefile</cacheFile>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.arcbees</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${build-tools.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>com.sun</groupId>
-                                <artifactId>tools</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>checkstyle</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>prod</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <appengine.app.id>docs-site</appengine.app.id>
+                <appengine.app.version>${maven.build.timestamp}</appengine.app.version>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>ci</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.arcbees.appengine</groupId>
+                        <artifactId>appengine-maven-plugin</artifactId>
+                        <configuration>
+                            <serverId>appengine-credentials</serverId>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>staging-gwtp</id>
+
+            <properties>
+                <appengine.app.id>doc-staging-gwtp</appengine.app.id>
+                <appengine.app.version>staging</appengine.app.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/webapp/src/test/java/com/google/gwt/site/webapp/Test.gwt.xml
+++ b/webapp/src/test/java/com/google/gwt/site/webapp/Test.gwt.xml
@@ -1,4 +1,3 @@
 <module rename-to="gwtproject">
-    <inherits name="com.google.gwt.user.User"/>
-    <inherits name="com.google.gwt.query.Query"/>
+    <inherits name="com.google.gwt.site.webapp.GWTProject"/>
 </module>


### PR DESCRIPTION
I also setup the CI to deploy the webapp and run the uploader against develop-gwtp. The result is pushed to a staging app: http://doc-staging-gwtp.appspot.com/

The same config (barring credentials) can easily be duplicated for other products (if needed).